### PR TITLE
fix: Propagate required_properties to primitives

### DIFF
--- a/tiny_gltf.h
+++ b/tiny_gltf.h
@@ -4949,7 +4949,7 @@ static bool ParseMesh(Mesh *mesh, Model *model, std::string *err, const json &o,
     }
   }
 
-  if (mesh->primitives.size() == 0) {
+  if (mesh->primitives.size() == 0 && required_properties) {
     // Size must be [1-*] https://registry.khronos.org/glTF/specs/2.0/glTF-2.0.html#reference-mesh
     return false;
   }


### PR DESCRIPTION
Propagate `required_properties` to primitives too (https://github.com/ambi-robotics/tinygltf/pull/1).